### PR TITLE
add MolLangBench and MolLangData

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,6 @@ The repository for [Leveraging Biomolecule and Natural Language through Multi-Mo
 * What can Large Language Models do in chemistry? A comprehensive benchmark on eight tasks [NeurIPS 2309](https://openreview.net/pdf?id=1ngbR3SZHW)
 * Do Large Language Models Understand Chemistry? A Conversation with ChatGPT [JCIM 2303](https://pubs.acs.org/doi/10.1021/acs.jcim.3c00285)
 * A Systematic Survey of Chemical Pre-trained Models [IJCAI 2023](https://www.ijcai.org/proceedings/2023/0760.pdf)
-* MolLangBench: A Comprehensive Benchmark for Language-Prompted Molecular Structure Recognition, Editing, and Generation [ICLR 2026](https://openreview.net/pdf?id=KbXl2jfFRn)
 
 ### Related Workshop
 * [Language + Molecules @ ACL 2024 Workshop](https://language-plus-molecules.github.io/)

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ The repository for [Leveraging Biomolecule and Natural Language through Multi-Mo
 - `Fine-tuning`- `Text, Molecule` [ExDDI](https://drive.google.com/drive/folders/1o2UgoPvMw6hunoewChw0ErumxXWJ4aTX?usp=sharing)
 - `Fine-tuning`- `Text, Molecule` [MMP](https://github.com/Cello2195/TransDLM/tree/main/datasets/mmp)
 - `Fine-tuning`- `Text, Molecule` [SLM4CRP_with_RTs](https://huggingface.co/datasets/liupf/SLM4CRP_with_RTs)
+- `Fine-tuning`- `Text, Molecule` [MolLangData](https://huggingface.co/datasets/ChemFM/MolLangData)
 - `Fine-tuning`- `Text, Molecule, etc` [SciAssess](https://sci-assess.github.io)
 - `Fine-tuning`- `Text, Molecule, etc` [DrugBank](https://github.com/SCIR-HI/ArtificiallyR2R)
 - `Fine-tuning`- `Text, Molecule, etc` [DARWIN](https://github.com/MasterAI-EAM/Darwin/tree/main/dataset)
@@ -394,6 +395,7 @@ The repository for [Leveraging Biomolecule and Natural Language through Multi-Mo
 * What can Large Language Models do in chemistry? A comprehensive benchmark on eight tasks [NeurIPS 2309](https://openreview.net/pdf?id=1ngbR3SZHW)
 * Do Large Language Models Understand Chemistry? A Conversation with ChatGPT [JCIM 2303](https://pubs.acs.org/doi/10.1021/acs.jcim.3c00285)
 * A Systematic Survey of Chemical Pre-trained Models [IJCAI 2023](https://www.ijcai.org/proceedings/2023/0760.pdf)
+* MolLangBench: A Comprehensive Benchmark for Language-Prompted Molecular Structure Recognition, Editing, and Generation [ICLR 2026](https://openreview.net/pdf?id=KbXl2jfFRn)
 
 ### Related Workshop
 * [Language + Molecules @ ACL 2024 Workshop](https://language-plus-molecules.github.io/)


### PR DESCRIPTION
Hi, 

Thanks for maintaining this repo. I've added our two recent works in this PR:

1. MolLangBench: I noticed it is already listed in the Benchmark section, and I have also added it to the Evaluation section, but I am not sure if this placement is appropriate.

2. MolLangData: I added it under Datasets & Benchmarks as a large-scale molecular structure description dataset.

Thank you!